### PR TITLE
feat: Add translation for app names and labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,14 @@ rebuild:
 	docker compose -f docker-compose.test.yml down
 	docker compose -f docker-compose.test.yml up -d --build
 	docker compose -f docker-compose.test.yml exec web python3 manage.py migrate
+	docker compose -f docker-compose.test.yml exec web python3 manage.py compilemessages
 	docker compose -f docker-compose.test.yml exec web python3 manage.py collectstatic --force
 
 rebuild-prod:
 	docker compose -f docker-compose.prod.yml down
 	docker compose -f docker-compose.prod.yml up -d --build
 	docker compose -f docker-compose.prod.yml exec web python3 manage.py migrate
+	docker compose -f docker-compose.test.yml exec web python3 manage.py compilemessages
 	docker compose -f docker-compose.prod.yml exec web python3 manage.py collectstatic --force
 
 restart-prod:

--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -1,6 +1,8 @@
 from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
 
 
 class AccountsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'accounts'
+    verbose_name = _('Аккаунты')

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AbstractUser, Group, UserManager
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class CustomUserManager(UserManager):
@@ -10,19 +11,19 @@ class CustomUserManager(UserManager):
         user = self._create_user(username, email, password, **extra_fields)
 
         # Add user to editor group:
-        editor_permission_group = Group.objects.get_or_create(name="Редактор")[0]
+        editor_permission_group = Group.objects.get_or_create(name=_("Редактор"))[0]
         user.groups.add(editor_permission_group)
 
         return user
 
 
 class CustomUser(AbstractUser):
-    text_size = models.IntegerField(null=True, blank=True, default=12, verbose_name='Размер текста')
+    text_size = models.IntegerField(null=True, blank=True, default=12, verbose_name=_('Размер текста'))
     objects = CustomUserManager()
 
 
 class UserSettings(CustomUser):
     class Meta:
         proxy = True
-        verbose_name = 'Настройки аккаунта'
-        verbose_name_plural = 'Настройки аккаунта'
+        verbose_name = _('Настройки аккаунта')
+        verbose_name_plural = _('Настройки аккаунта')

--- a/books/admin_forms.py
+++ b/books/admin_forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.admin.helpers import ActionForm
+from django.utils.translation import gettext_lazy as _
 
 from books.models import Page
 
@@ -23,4 +24,4 @@ class PageAdminForm(forms.ModelForm):
 
 
 class ActionValueForm(ActionForm):
-    action_value = forms.CharField(label='значение')
+    action_value = forms.CharField(label=_('значение'))

--- a/books/apps.py
+++ b/books/apps.py
@@ -1,6 +1,8 @@
 from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
 
 
 class BooksConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'books'
+    verbose_name = _('Книги')

--- a/books/models.py
+++ b/books/models.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
 from django_lifecycle import AFTER_CREATE, LifecycleModelMixin, hook
 from simple_history.models import HistoricalRecords
@@ -17,8 +18,8 @@ class Author(models.Model):
 
     class Meta:
         db_table = '"book"."author"'
-        verbose_name = "Автор"
-        verbose_name_plural = "Авторы"
+        verbose_name = _("Автор")
+        verbose_name_plural = _("Авторы")
 
 
 class Book(LifecycleModelMixin, models.Model):
@@ -30,8 +31,8 @@ class Book(LifecycleModelMixin, models.Model):
 
     class Meta:
         db_table = '"book"."book"'
-        verbose_name = "Книга"
-        verbose_name_plural = "Книги"
+        verbose_name = _("Книга")
+        verbose_name_plural = _("Книги")
 
     def __str__(self):
         return self.name
@@ -43,21 +44,23 @@ class Book(LifecycleModelMixin, models.Model):
 
 class Page(LifecycleModelMixin, TimeStampedModel, models.Model):
     class Status(models.TextChoices):
-        PROCESSING = "processing", "Распознавание"
-        READY = "redy", "Распознано"
-        IN_PROGRESS = "in_progress", "Вычитка"
-        FORMATTING = "formatting", "Форматирование"
-        CHECK = "check", "Проверка"
-        DONE = "done", "Завершено"
+        PROCESSING = "processing", _("Распознавание")
+        READY = "redy", _("Распознано")
+        IN_PROGRESS = "in_progress", _("Вычитка")
+        FORMATTING = "formatting", _("Форматирование")
+        CHECK = "check", _("Проверка")
+        DONE = "done", _("Завершено")
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    book = models.ForeignKey(Book, on_delete=models.CASCADE, related_name="pages", verbose_name="Книга")
-    number = models.IntegerField(verbose_name="Порядковый номер страницы")
+    book = models.ForeignKey(Book, on_delete=models.CASCADE, related_name="pages", verbose_name=_("Книга"))
+    number = models.IntegerField(verbose_name=_("Порядковый номер страницы"))
     image_url = models.TextField(blank=True)
     image = models.FileField(upload_to="pages/", null=True, blank=True)
     text = models.TextField(blank=True)
-    status = models.CharField(max_length=100, choices=Status.choices, default=Status.PROCESSING, verbose_name="Статус")
-    number_in_book = models.CharField(null=True, blank=True, verbose_name="Номер страницы в книге", max_length=100)
+    status = models.CharField(
+        max_length=100, choices=Status.choices, default=Status.PROCESSING, verbose_name=_("Статус")
+    )
+    number_in_book = models.CharField(null=True, blank=True, verbose_name=_("Номер страницы в книге"), max_length=100)
 
     history = HistoricalRecords()
 
@@ -66,8 +69,8 @@ class Page(LifecycleModelMixin, TimeStampedModel, models.Model):
 
     class Meta:
         db_table = '"book"."page"'
-        verbose_name = "Страница"
-        verbose_name_plural = "Страницы"
+        verbose_name = _("Страница")
+        verbose_name_plural = _("Страницы")
 
     @hook(AFTER_CREATE, on_commit=True, when="image", is_not=None)
     def extract_text_from_image(self):

--- a/books/templates/admin/page_change_form.html
+++ b/books/templates/admin/page_change_form.html
@@ -1,35 +1,50 @@
 {% extends "admin/change_form.html" %}
 {% load static %}
+{% load i18n %}
+
 {% block extrahead %}
     {{ block.super }}
-    <!-- Add these links to your admin template's head section -->
+    <!-- Static files for custom styles -->
     <link rel="stylesheet" type="text/css" href="{% static 'css/reader.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'css/ckeditor5-dark.css' %}">
+
+    <!-- Inline style for form row adjustments -->
     <style>.form-row p{font-size: inherit;}</style>
+
+    <!-- External stylesheet for viewer.js -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.6/viewer.min.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
-    <button type="button" id="correctTextButton">Улучшить форматирование</button>
+    <!-- Custom button for text formatting -->
+    <button type="button" id="correctTextButton">{% trans "Улучшить форматирование" %}</button>
 
+    <!-- Default admin form content -->
     {{ block.super }}
 {% endblock %}
 
-
 {% block submit_buttons_bottom %}
-    <input type="submit" value="Сохранить" class="default" name="_continue">
+    <!-- Save button -->
+    <input type="submit" value="{% trans 'Сохранить' %}" class="default" name="_continue">
+
+    <!-- Navigation buttons for multi-page forms -->
     {% if prev_page_exists %}
-        <input type="submit" value="<- Предыдущая страница" class="default" name="back_page">
+        <input type="submit" value="{% trans '<- Предыдущая страница' %}" class="default" name="back_page">
     {% endif %}
     {% if next_page_exists %}
-        <input type="submit" value="Следующая страница ->" class="default" name="next_page">
-        <input type="submit" value="Сохранить и перейти к следующей странице ->" class="default" name="_save">
+        <input type="submit" value="{% trans 'Следующая страница ->' %}" class="default" name="next_page">
+        <input type="submit" value="{% trans 'Сохранить и перейти к следующей странице ->' %}" class="default" name="_save">
     {% endif %}
 {% endblock %}
 
 {% block admin_change_form_document_ready %}
+    <!-- jQuery library -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+    <!-- Viewer.js for image viewing -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.6/viewer.min.js"></script>
+
+    <!-- Custom JavaScript files -->
     <script type="text/javascript" src="{% static 'js/zoom_picture_overlay.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/ckeditor5.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/markdown.js' %}"></script>

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -1,0 +1,207 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-12-04 16:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: accounts/apps.py:8
+msgid "Аккаунты"
+msgstr ""
+
+#: accounts/models.py:14
+msgid "Редактор"
+msgstr ""
+
+#: accounts/models.py:21 books/admin.py:208
+msgid "Размер текста"
+msgstr ""
+
+#: accounts/models.py:28 accounts/models.py:29
+msgid "Настройки аккаунта"
+msgstr ""
+
+#: books/admin.py:30
+msgid "Скачать книгу текстовым файлом"
+msgstr ""
+
+#: books/admin.py:36
+msgid "Задачи по распознаванию текста запущены"
+msgstr ""
+
+#: books/admin.py:39
+msgid "Повторно запустить задачи по распознаванию текста"
+msgstr ""
+
+#: books/admin.py:46
+msgid "Задачи по разделению страниц запущены"
+msgstr ""
+
+#: books/admin.py:49
+msgid "Повторно запустить задачи по разделению страниц"
+msgstr ""
+
+#: books/admin.py:95 books/models.py:46
+msgid "Распознавание"
+msgstr ""
+
+#: books/admin.py:97 books/models.py:51
+msgid "Завершено"
+msgstr ""
+
+#: books/admin.py:99 books/models.py:48
+msgid "Вычитка"
+msgstr ""
+
+#: books/admin.py:118 books/models.py:33 books/models.py:54
+msgid "Книга"
+msgstr ""
+
+#: books/admin.py:128
+msgid "Введите целое число"
+msgstr ""
+
+#: books/admin.py:137
+msgid "Задача по нумерации страниц запущена"
+msgstr ""
+
+#: books/admin.py:140
+msgid "Запустить задачу по нумерации страниц"
+msgstr ""
+
+#: books/admin_forms.py:27
+msgid "значение"
+msgstr ""
+
+#: books/apps.py:8 books/models.py:34
+msgid "Книги"
+msgstr ""
+
+#: books/models.py:20
+msgid "Автор"
+msgstr ""
+
+#: books/models.py:21
+msgid "Авторы"
+msgstr ""
+
+#: books/models.py:47
+msgid "Распознано"
+msgstr ""
+
+#: books/models.py:49
+msgid "Форматирование"
+msgstr ""
+
+#: books/models.py:50
+msgid "Проверка"
+msgstr ""
+
+#: books/models.py:55
+msgid "Порядковый номер страницы"
+msgstr ""
+
+#: books/models.py:60
+msgid "Статус"
+msgstr ""
+
+#: books/models.py:61
+msgid "Номер страницы в книге"
+msgstr ""
+
+#: books/models.py:70
+msgid "Страница"
+msgstr ""
+
+#: books/models.py:71
+msgid "Страницы"
+msgstr ""
+
+#: books/templates/admin/page_change_form.html:20
+msgid "Улучшить форматирование"
+msgstr ""
+
+#: books/templates/admin/page_change_form.html:28
+msgid "Сохранить"
+msgstr ""
+
+#: books/templates/admin/page_change_form.html:32
+msgid "<- Предыдущая страница"
+msgstr ""
+
+#: books/templates/admin/page_change_form.html:35
+msgid "Следующая страница ->"
+msgstr ""
+
+#: books/templates/admin/page_change_form.html:36
+msgid "Сохранить и перейти к следующей странице ->"
+msgstr ""
+
+#: templates/admin/login.html:27
+msgid "Пожалуйста исправьте ошибку ниже."
+msgid_plural "Пожалуйста исправьте ошибки ниже."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/admin/login.html:43
+#, python-format
+msgid ""
+"You are authenticated as %(username)s, but are not authorized to access this "
+"page. Would you like to login to a different account?"
+msgstr ""
+
+#: templates/admin/login.html:63
+msgid "Забыли ваш пароль?"
+msgstr ""
+
+#: templates/admin/login.html:67
+msgid "Войти"
+msgstr ""
+
+#: templates/admin/login.html:69 templates/registration/signup.html:5
+#: templates/registration/signup.html:11
+msgid "Регистрация"
+msgstr ""
+
+#: templates/history/_object_history_list.html:9
+msgid "Object"
+msgstr ""
+
+#: templates/history/_object_history_list.html:13
+msgid "Date/time"
+msgstr ""
+
+#: templates/history/_object_history_list.html:14
+msgid "Changed by"
+msgstr ""
+
+#: templates/history/_object_history_list.html:34
+msgid "None"
+msgstr ""
+
+#: templates/history/object_history.html:11
+msgid ""
+"Choose a date from the list below to revert to a previous version of this "
+"object."
+msgstr ""
+
+#: templates/history/object_history.html:16
+msgid "This object doesn't have a change history."
+msgstr ""
+
+#: templates/registration/signup.html:15
+msgid "Зарегистрироваться"
+msgstr ""

--- a/proofreader/settings.py
+++ b/proofreader/settings.py
@@ -95,6 +95,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    'django.middleware.locale.LocaleMiddleware',
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -153,17 +154,6 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
-
-# Internationalization
-# https://docs.djangoproject.com/en/4.0/topics/i18n/
-
-LANGUAGE_CODE = "ru"
-
-TIME_ZONE = "UTC"
-
-USE_I18N = True
-
-USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
@@ -239,3 +229,18 @@ STORAGES = {
     },
 }
 SIMPLE_HISTORY_ENFORCE_HISTORY_MODEL_PERMISSIONS = True
+
+# Internationalization
+# https://docs.djangoproject.com/en/4.0/topics/i18n/
+
+LANGUAGE_CODE = "ru"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+LOCALE_PATHS = [
+    os.path.join(BASE_DIR, 'locale'),
+]
+LANGUAGES = [
+    ('eo', 'Esperanto'),
+    ('ru', 'Russian'),
+]

--- a/proofreader/urls.py
+++ b/proofreader/urls.py
@@ -14,13 +14,15 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
+from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path, re_path
 
-urlpatterns = [
+urlpatterns = i18n_patterns(
     path("home/", admin.site.urls),
     path("", include("accounts.urls")),
     path("tz_detect/", include("tz_detect.urls")),
     re_path(r'^api/v1/', include('proofreader.api_urls', namespace='v1')),
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    prefix_default_language=False,
+) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -24,7 +24,7 @@
 {% block content %}
 {% if form.errors and not form.non_field_errors %}
 <p class="errornote">
-{% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+{% blocktranslate count counter=form.errors.items|length %}Пожалуйста исправьте ошибку ниже.{% plural %}Пожалуйста исправьте ошибки ниже.{% endblocktranslate %}
 </p>
 {% endif %}
 
@@ -60,13 +60,13 @@
   {% url 'admin_password_reset' as password_reset_url %}
   {% if password_reset_url %}
   <div class="password-reset-link">
-    <a href="{{ password_reset_url }}">{% translate 'Forgotten your password or username?' %}</a>
+    <a href="{{ password_reset_url }}">{% translate 'Забыли ваш пароль?' %}</a>
   </div>
   {% endif %}
   <div class="submit-row">
-    <input type="submit" value="{% translate 'Log in' %}">
+    <input type="submit" value="{% translate 'Войти' %}">
   </div>
-    <a href="{% url "signup" %}">Регистрация</a>
+    <a href="{% url "signup" %}">{% translate 'Регистрация' %}</a>
 </form>
 
 </div>

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -1,17 +1,18 @@
 {% extends 'base.html' %}
 {% load crispy_forms_tags %}
+{% load i18n %}
 {% block title %}
-    Регистрация
+    {% trans 'Регистрация' %}
 {% endblock title %}
 {% block content %}
     <div class="container-xxl my-5">
         <div class="row justify-content-center">
             <div class="col-3">
-                <h2>Регистрация</h2>
+                <h2>{% trans 'Регистрация' %}</h2>
                 <form method="post">
                     {% csrf_token %}
                     {{ form|crispy }}
-                    <button class="btn btn-success ml-2" type="submit">Зарегистрироваться</button>
+                    <button class="btn btn-success ml-2" type="submit">{% trans 'Зарегистрироваться' %}</button>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
- Added translations for the verbose names of the "Accounts" and "Books" apps.
- Translated various labels and button texts in the admin interface.
- Updated import statements to include the `gettext_lazy` function from Django's translation module.
